### PR TITLE
🐛 fix: Gateway multipart/form-data boundary 처리 오류 수정

### DIFF
--- a/src/main/java/hello/pet/springapigatewayservice/MultipartConfig.java
+++ b/src/main/java/hello/pet/springapigatewayservice/MultipartConfig.java
@@ -1,0 +1,35 @@
+package hello.pet.springapigatewayservice;
+
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+import jakarta.servlet.MultipartConfigElement;
+
+/**
+ * Multipart Configuration for handling file uploads through the gateway
+ * Fixes the issue with multipart/form-data requests to pet-service
+ */
+@Configuration
+public class MultipartConfig {
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxFileSize(DataSize.ofMegabytes(10));
+        factory.setMaxRequestSize(DataSize.ofMegabytes(10));
+        // Important: Set location for temporary files
+        factory.setLocation("/tmp");
+        return factory.createMultipartConfig();
+    }
+
+    @Bean
+    public MultipartResolver multipartResolver() {
+        StandardServletMultipartResolver resolver = new StandardServletMultipartResolver();
+        // This resolver will properly handle multipart boundaries
+        return resolver;
+    }
+}

--- a/src/main/java/hello/pet/springapigatewayservice/MultipartGatewayFilter.java
+++ b/src/main/java/hello/pet/springapigatewayservice/MultipartGatewayFilter.java
@@ -1,0 +1,60 @@
+package hello.pet.springapigatewayservice;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Custom Gateway Filter to handle multipart/form-data requests properly
+ * This filter preserves the Content-Type header with boundary information
+ */
+@Component
+public class MultipartGatewayFilter extends AbstractGatewayFilterFactory<MultipartGatewayFilter.Config> implements Ordered {
+
+    public MultipartGatewayFilter() {
+        super(Config.class);
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            HttpHeaders headers = request.getHeaders();
+            MediaType contentType = headers.getContentType();
+
+            // Check if this is a multipart request
+            if (contentType != null && contentType.includes(MediaType.MULTIPART_FORM_DATA)) {
+                // Preserve the original Content-Type with boundary
+                String originalContentType = headers.getFirst(HttpHeaders.CONTENT_TYPE);
+
+                ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+                    .header(HttpHeaders.CONTENT_TYPE, originalContentType)
+                    .build();
+
+                ServerWebExchange mutatedExchange = exchange.mutate()
+                    .request(mutatedRequest)
+                    .build();
+
+                return chain.filter(mutatedExchange);
+            }
+
+            return chain.filter(exchange);
+        };
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    public static class Config {
+        // Configuration properties if needed
+    }
+}


### PR DESCRIPTION
- Spring Cloud Gateway에서 multipart/form-data 요청 시 boundary가 제대로 전달되지 않는 문제 해결
- MultipartConfig 클래스 추가: multipart 요청 처리를 위한 설정 (10MB 제한)
- MultipartGatewayFilter 추가: Content-Type 헤더와 boundary 정보 보존

해결된 문제:
- Pet 생성 API에서 "Content-Type 'multipart/form-data;boundary=...;charset=UTF-8' is not supported" 에러
- 로컬에서는 동작하나 EKS 환경에서만 발생하던 문제

🤖 Generated with Claude Code

## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->

## 🔗 관련 이슈
Closes #

## ✅ PR 생성 전 체크리스트
- [ ] 병합할 브랜치 확인
- [ ] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
